### PR TITLE
Vectorize SPA implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
-# Aletheia
+# Deepsteg
 
+Deepsteg is based off of daniellerch's package Aletheia.
 
 Aletheia is an open source image steganalysis tool for the detection of hidden messages in images. To achieve its objectives, Aletheia uses state-of-the-art machine learning techniques. It is capable of detecting several different steganographic methods as for example LSB replacement, LSB matching and some kind of adaptive schemes.
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ Deepsteg is based off of daniellerch's package Aletheia.
 
 ## Current Deepsteg Goals:
  - create a training set of images that have hidden data using steghide, rgb, train neural network to detect steghide steganography
+ 
+## What is Aletheia?
 
 Aletheia is an open source image steganalysis tool for the detection of hidden messages in images. To achieve its objectives, Aletheia uses state-of-the-art machine learning techniques. It is capable of detecting several different steganographic methods as for example LSB replacement, LSB matching and some kind of adaptive schemes.
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@
 
 Deepsteg is based off of daniellerch's package Aletheia.
 
+## Current Deepsteg Goals:
+ - create a training set of images that have hidden data using steghide, rgb, train neural network to detect steghide steganography
+
 Aletheia is an open source image steganalysis tool for the detection of hidden messages in images. To achieve its objectives, Aletheia uses state-of-the-art machine learning techniques. It is capable of detecting several different steganographic methods as for example LSB replacement, LSB matching and some kind of adaptive schemes.
 
 

--- a/aletheia.py
+++ b/aletheia.py
@@ -120,15 +120,15 @@ def main():
 
         I = imread(sys.argv[2])
         if len(I.shape)==2:
-            bitrate=attacks.spa(sys.argv[2], None)
+            bitrate=attacks.spa_image(I, None)
             if bitrate<threshold:
                 print("No hidden data found")
             else:
                 print("Hiden data found"), bitrate
         else:
-            bitrate_R=attacks.spa(sys.argv[2], 0)
-            bitrate_G=attacks.spa(sys.argv[2], 1)
-            bitrate_B=attacks.spa(sys.argv[2], 2)
+            bitrate_R=attacks.spa_image(I, 0)
+            bitrate_G=attacks.spa_image(I, 1)
+            bitrate_B=attacks.spa_image(I, 2)
 
             if bitrate_R<threshold and bitrate_G<threshold and bitrate_B<threshold:
                 print("No hidden data found")

--- a/aletheia.py
+++ b/aletheia.py
@@ -14,7 +14,7 @@ import random
 import tempfile
 import subprocess
 
-from scipy import misc
+from imageio import imread
 
 from aletheialib import attacks, utils
 from aletheialib import stegosim, feaext, models
@@ -118,7 +118,7 @@ def main():
 
         threshold=0.05
 
-        I = misc.imread(sys.argv[2])
+        I = imread(sys.argv[2])
         if len(I.shape)==2:
             bitrate=attacks.spa(sys.argv[2], None)
             if bitrate<threshold:
@@ -158,7 +158,7 @@ def main():
         threshold=0.05
 
 
-        I = misc.imread(sys.argv[2])
+        I = imread(sys.argv[2])
         if len(I.shape)==2:
             bitrate=attacks.rs(sys.argv[2], None)
             if bitrate<threshold:

--- a/aletheia.py
+++ b/aletheia.py
@@ -17,7 +17,7 @@ import subprocess
 from imageio import imread
 
 from aletheialib import attacks, utils
-from aletheialib import stegosim, feaext, models
+from aletheialib import stegosim, feaext
 from aletheialib import inconsistencies
 
 
@@ -242,6 +242,7 @@ def main():
 
     # {{{ e4s-predict
     elif sys.argv[1]=="e4s-predict":
+        from aletheialib import models
 
         if len(sys.argv)!=5:
             print(sys.argv[0], "e4s-predict <model-file> <feature-extractor> <image/dir>\n")
@@ -282,6 +283,7 @@ def main():
 
     # {{{ srnet-predict
     elif sys.argv[1]=="srnet-predict":
+        from aletheialib import models
 
         if len(sys.argv)<4:
             print(sys.argv[0], "srnet-predict <model dir> <image/dir> [dev]\n")
@@ -324,6 +326,7 @@ def main():
 
     # {{{ srnet-score
     elif sys.argv[1]=="srnet-err":
+        from aletheialib import models
 
         if len(sys.argv)<4:
             print(sys.argv[0], "srnet-score <model dir> <cover dir> <stego dir> [dev]\n")
@@ -388,6 +391,7 @@ def main():
 
     # {{{ srnet-score
     elif sys.argv[1]=="srnet-err-icd":
+        from aletheialib import models
 
         if len(sys.argv)<6:
             print(sys.argv[0], "srnet-score-icd <A model dir> <B model dir> <A cover dir> <A stego dir> <B cover dir> <B stego dir> [dev]\n")
@@ -733,6 +737,7 @@ def main():
 
     # {{{ esvm
     elif sys.argv[1]=="esvm":
+        from aletheialib import models
 
         if len(sys.argv)!=5:
             print(sys.argv[0], "esvm <cover-fea> <stego-fea> <model-file>\n")
@@ -763,6 +768,7 @@ def main():
 
     # {{{ e4s
     elif sys.argv[1]=="e4s":
+        from aletheialib import models
 
         if len(sys.argv)!=5:
             print(sys.argv[0], "e4s <cover-fea> <stego-fea> <model-file>\n")
@@ -793,6 +799,7 @@ def main():
 
     # {{{ srnet
     elif sys.argv[1]=="srnet":
+        from aletheialib import models
 
         if len(sys.argv)<5:
             print(sys.argv[0], "srnet <cover-dir> <stego-dir> <model-name> [dev] [max_iter] [ES] [valsz] [logdir]\n")
@@ -876,6 +883,7 @@ def main():
 
     # {{{ ats
     elif sys.argv[1]=="ats":
+        from aletheialib import models
 
         if len(sys.argv) not in [5, 6]:
             print(sys.argv[0], "ats <embed-sim> <payload> <fea-extract> <images>")

--- a/aletheialib/attacks.py
+++ b/aletheialib/attacks.py
@@ -59,13 +59,14 @@ def exif(filename):
     Return Beta, the detected embedding rate.
 """
 def spa(filename, channel=0): 
+    return spa_image(imread(filename))
 
+def spa_image(image, channel=0):
     if channel!=None:
-        I3d = imread(filename)
-        width, height, channels = I3d.shape
-        I = I3d[:,:,channel]
+        width, height, channels = image.shape
+        I = image[:,:,channel]
     else:
-        I = imread(filename)
+        I = image
         width, height = I.shape
 
     x=0; y=0; k=0

--- a/aletheialib/attacks.py
+++ b/aletheialib/attacks.py
@@ -69,20 +69,24 @@ def spa_image(image, channel=0):
         I = image
         width, height = I.shape
 
-    x=0; y=0; k=0
-    for j in range(height):
-        for i in range(width-1):
-            r = I[i, j]
-            s = I[i+1, j]
-            mod_is_zero = s % 2 == 0
-            r_less_than_s = r < s
-            r_greater_than_s = r > s
-            if (mod_is_zero and r_less_than_s) or (not mod_is_zero and r_greater_than_s):
-                x+=1
-            if (mod_is_zero and r_greater_than_s) or (not mod_is_zero and r_less_than_s):
-                y+=1
-            if s / 2 == r / 2:
-                k+=1
+    r = I[:-1,:]
+    s = I[1:,:]
+
+    # we only care about the lsb of the next pixel
+    lsb_is_zero = np.equal(np.bitwise_and(s, 1), 0)
+    lsb_non_zero = np.bitwise_and(s, 1)
+    msb = np.bitwise_and(I, 0xFE)
+
+    r_less_than_s = np.less(r, s)
+    r_greater_than_s = np.greater(r, s)
+
+    x = np.sum(np.logical_or(np.logical_and(lsb_is_zero, r_less_than_s),
+                             np.logical_and(lsb_non_zero, r_greater_than_s)).astype(int))
+
+    y = np.sum(np.logical_or(np.logical_and(lsb_is_zero, r_greater_than_s),
+                             np.logical_and(lsb_non_zero, r_less_than_s)).astype(int))
+
+    k = np.sum(np.equal(msb[:-1,:], msb[1:,:]).astype(int))
 
     if k==0:
         print("ERROR")

--- a/aletheialib/attacks.py
+++ b/aletheialib/attacks.py
@@ -74,11 +74,14 @@ def spa_image(image, channel=0):
         for i in range(width-1):
             r = I[i, j]
             s = I[i+1, j]
-            if (s%2==0 and r<s) or (s%2==1 and r>s):
+            mod_is_zero = s % 2 == 0
+            r_less_than_s = r < s
+            r_greater_than_s = r > s
+            if (mod_is_zero and r_less_than_s) or (not mod_is_zero and r_greater_than_s):
                 x+=1
-            if (s%2==0 and r>s) or (s%2==1 and r<s):
+            if (mod_is_zero and r_greater_than_s) or (not mod_is_zero and r_less_than_s):
                 y+=1
-            if round(s/2)==round(r/2):
+            if s / 2 == r / 2:
                 k+=1
 
     if k==0:

--- a/aletheialib/attacks.py
+++ b/aletheialib/attacks.py
@@ -10,8 +10,9 @@ import subprocess
 from aletheialib import stegosim, utils
 
 import numpy as np
-from scipy import ndimage, misc
+from scipy import ndimage
 from cmath import sqrt
+from imageio import imread
 
 from PIL import Image
 from PIL.ExifTags import TAGS
@@ -30,9 +31,9 @@ def extra_size(filename):
     print("WARNING! not implemented")
 
     name=ntpath.basename(filename)
-    I = misc.imread(filename)
+    I = imread(filename)
 
-    misc.imsave(tempfile.gettempdir()+'/'+name, I)
+    imsave(tempfile.gettempdir()+'/'+name, I)
     return 0
 
 
@@ -60,11 +61,11 @@ def exif(filename):
 def spa(filename, channel=0): 
 
     if channel!=None:
-        I3d = misc.imread(filename)
+        I3d = imread(filename)
         width, height, channels = I3d.shape
         I = I3d[:,:,channel]
     else:
-        I = misc.imread(filename)
+        I = imread(filename)
         width, height = I.shape
 
     x=0; y=0; k=0
@@ -136,7 +137,7 @@ def difference(I, mask):
 
 # {{{ rs()
 def rs(filename, channel=0):
-    I = misc.imread(filename)
+    I = imread(filename)
     if channel!=None:
         I = I[:,:,channel]
     I = I.astype(int)
@@ -202,7 +203,7 @@ def calibration(filename):
 # {{{ high_pass_filter()
 def high_pass_filter(input_image, output_image): 
 
-    I = misc.imread(input_image)
+    I = imread(input_image)
     if len(I.shape)==3:
         kernel = np.array([[[-1, -1, -1],
                             [-1,  8, -1],
@@ -220,13 +221,13 @@ def high_pass_filter(input_image, output_image):
 
 
     If = ndimage.convolve(I, kernel)
-    misc.imsave(output_image, If)
+    imsave(output_image, If)
 # }}}
 
 # {{{ low_pass_filter()
 def low_pass_filter(input_image, output_image): 
 
-    I = misc.imread(input_image)
+    I = imread(input_image)
     if len(I.shape)==3:
         kernel = np.array([[[1, 1, 1],
                             [1, 1, 1],
@@ -244,14 +245,14 @@ def low_pass_filter(input_image, output_image):
 
     kernel = kernel.astype('float32')/9
     If = ndimage.convolve(I, kernel)
-    misc.imsave(output_image, If)
+    imsave(output_image, If)
 # }}}
 
 # {{{ imgdiff()
 def imgdiff(image1, image2): 
 
-    I1 = misc.imread(image1).astype('int16')
-    I2 = misc.imread(image2).astype('int16')
+    I1 = imread(image1).astype('int16')
+    I2 = imread(image2).astype('int16')
     np.set_printoptions(threshold=sys.maxsize)
 
     if len(I1.shape) != len(I2.shape):
@@ -282,8 +283,8 @@ def imgdiff(image1, image2):
 # {{{ imgdiff_pixels()
 def imgdiff_pixels(image1, image2): 
 
-    I1 = misc.imread(image1).astype('int16')
-    I2 = misc.imread(image2).astype('int16')
+    I1 = imread(image1).astype('int16')
+    I2 = imread(image2).astype('int16')
     np.set_printoptions(threshold=sys.maxsize)
 
     if len(I1.shape) != len(I2.shape):
@@ -330,8 +331,8 @@ def print_diffs(cover, stego):
             print(l[i:i+ln])
 
 
-    C = misc.imread(cover).astype('int16')
-    S = misc.imread(stego).astype('int16')
+    C = imread(cover).astype('int16')
+    S = imread(stego).astype('int16')
     np.set_printoptions(threshold=sys.maxsize)
 
     if len(C.shape) != len(S.shape):
@@ -392,9 +393,9 @@ def print_dct_diffs(cover, stego):
 # {{{ remove_alpha_channel()
 def remove_alpha_channel(input_image, output_image): 
 
-    I = misc.imread(input_image)
+    I = imread(input_image)
     I[:,:,3] = 255;
-    misc.imsave(output_image, I)
+    imsave(output_image, I)
 # }}}
 
 # {{{ brute_force()

--- a/aletheialib/models.py
+++ b/aletheialib/models.py
@@ -19,7 +19,8 @@ from sklearn import svm
 
 import hdf5storage
 from scipy.io import savemat, loadmat
-from scipy import misc, signal # ndimage
+from scipy import signal # ndimage
+from imageio import imread
 
 from multiprocessing.dummy import Pool as ThreadPool
 from multiprocessing import cpu_count
@@ -275,7 +276,6 @@ import tensorflow as tf
 tf.logging.set_verbosity(tf.logging.ERROR)
 
 
-from scipy import misc
 from functools import partial
 from sklearn.metrics import accuracy_score
 
@@ -379,7 +379,7 @@ def _train_data_generator(cover_files, stego_files, data_augm=False,
             len(cover_list), "!=", len(stego_list))
         sys.exit(0)
 
-    img = misc.imread(cover_list[0])[:crop_size,:crop_size]
+    img = imread(cover_list[0])[:crop_size,:crop_size]
     batch = np.empty((2, img.shape[0], img.shape[1],1), dtype='uint8')
     iterable = list(zip(cover_list, stego_list))
     while True:
@@ -387,8 +387,8 @@ def _train_data_generator(cover_files, stego_files, data_augm=False,
             random.shuffle(iterable)
         for cover_path, stego_path in iterable:
             labels = np.array([0, 1], dtype='uint8')
-            batch[0,:,:,0] = misc.imread(cover_path)[:crop_size,:crop_size]
-            batch[1,:,:,0] = misc.imread(stego_path)[:crop_size,:crop_size]
+            batch[0,:,:,0] = imread(cover_path)[:crop_size,:crop_size]
+            batch[1,:,:,0] = imread(stego_path)[:crop_size,:crop_size]
 
             if data_augm:
                 rot = random.randint(0,3)
@@ -408,12 +408,12 @@ def _train_data_generator(cover_files, stego_files, data_augm=False,
 def _test_data_generator(files, crop_size=256):
 
     nb_data = len(files)
-    img = misc.imread(files[0])[:crop_size,:crop_size]
+    img = imread(files[0])[:crop_size,:crop_size]
     batch = np.empty((1, img.shape[0], img.shape[1],1), dtype='uint8')
     while True:
         for path in files:
             labels = np.array([0], dtype='uint8')
-            batch[0,:,:,0] = misc.imread(path)[:crop_size,:crop_size]
+            batch[0,:,:,0] = imread(path)[:crop_size,:crop_size]
             yield [batch, labels]
 # }}}        
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 numpy
 scipy
-tensorflow
+tensorflow==1.15.0
 keras
 scikit-learn
 scikit-image


### PR DESCRIPTION
This PR speeds up SPA by more than 40x by using numpy primitives rather than hand rolling the loops. It also locks the tensorflow requirement to 1.15 because 2.x isn't compatible at the moment and uses's imageio's imread as scipy no longer gets it through Pillow.

I originally forked from @GohanSebastianBach, so it pulled in some of his README updates.