### PR TITLE
RS speedup work

### DIFF
--- a/aletheia.py
+++ b/aletheia.py
@@ -303,7 +303,7 @@ def main():
     elif sys.argv[1]=="rs":
 
         if len(sys.argv)!=3:
-            print(sys.argv[0], "spa <image>\n")
+            print(sys.argv[0], "rs <image>\n")
             sys.exit(0)
 
         if not utils.is_valid_image(sys.argv[2]):
@@ -315,15 +315,15 @@ def main():
 
         I = imread(sys.argv[2])
         if len(I.shape)==2:
-            bitrate=attacks.rs(sys.argv[2], None)
+            bitrate=attacks.rs_image(I)
             if bitrate<threshold:
                 print("No hidden data found")
             else:
                 print("Hiden data found", bitrate)
         else:
-            bitrate_R=attacks.rs(sys.argv[2], 0)
-            bitrate_G=attacks.rs(sys.argv[2], 1)
-            bitrate_B=attacks.rs(sys.argv[2], 2)
+            bitrate_R=attacks.rs_image(I, 0)
+            bitrate_G=attacks.rs_image(I, 1)
+            bitrate_B=attacks.rs_image(I, 2)
 
             if bitrate_R<threshold and bitrate_G<threshold and bitrate_B<threshold:
                 print("No hidden data found")

--- a/aletheia.py
+++ b/aletheia.py
@@ -313,7 +313,7 @@ def main():
         threshold=0.05
 
 
-        I = imread(sys.argv[2])
+        I = np.asarray(imread(sys.argv[2]))
         if len(I.shape)==2:
             bitrate=attacks.rs_image(I)
             if bitrate<threshold:

--- a/aletheialib/attacks.py
+++ b/aletheialib/attacks.py
@@ -59,7 +59,7 @@ def exif(filename):
     Return Beta, the detected embedding rate.
 """
 def spa(filename, channel=0): 
-    return spa_image(imread(filename))
+    return spa_image(imread(filename), channel)
 
 def spa_image(image, channel=0):
     if channel!=None:
@@ -148,9 +148,13 @@ def difference(I, mask):
 
 # {{{ rs()
 def rs(filename, channel=0):
-    I = imread(filename)
+    return rs_image(imread(filename), channel)
+
+def rs_image(image, channel=0):
     if channel!=None:
-        I = I[:,:,channel]
+        I = image[:,:,channel]
+    else:
+        I = image
     I = I.astype(int)
 
     mask = np.array( [[1,0],[0,1]] )

--- a/aletheialib/attacks.py
+++ b/aletheialib/attacks.py
@@ -148,7 +148,7 @@ def difference(I, mask):
 
 # {{{ rs()
 def rs(filename, channel=0):
-    return rs_image(imread(filename), channel)
+    return rs_image(np.asarray(imread(filename), channel))
 
 def rs_image(image, channel=0):
     if channel!=None:

--- a/aletheialib/attacks.py
+++ b/aletheialib/attacks.py
@@ -114,7 +114,7 @@ def solve(a, b, c):
 
 # {{{ smoothness()
 def smoothness(I):
-    return ( np.sum(np.abs( I[:-1,:] - I[1:,:] )) + 
+    return ( np.sum(np.abs( I[:-1,:] - I[1:,:] )) +
              np.sum(np.abs( I[:,:-1] - I[:,1:] )) )
 # }}}
 
@@ -157,7 +157,7 @@ def rs_image(image, channel=0):
         I = image
     I = I.astype(int)
 
-    mask = np.array( [[1,0],[0,1]] )
+    mask = np.array( [[0, 0, 0], [0, 1, 0], [0, 0, 0]] )
     d0 = difference(I, mask)
     d1 = difference(I^1, mask)
 
@@ -165,10 +165,10 @@ def rs_image(image, channel=0):
     n_d0 = difference(I, mask)
     n_d1 = difference(I^1, mask)
 
-    p0, p1 = solve(2*(d1+d0), (n_d0-n_d1-d1-3*d0), (d0-n_d0)) 
-    if np.abs(p0) < np.abs(p1): 
+    p0, p1 = solve(2*(d1+d0), (n_d0-n_d1-d1-3*d0), (d0-n_d0))
+    if np.abs(p0) < np.abs(p1):
         z = p0
-    else: 
+    else:
         z = p1
 
     return z / (z-0.5)

--- a/aletheialib/attacks.py
+++ b/aletheialib/attacks.py
@@ -121,25 +121,28 @@ def smoothness(I):
 # {{{ groups()
 def groups(I, mask):
     grp=[]
-    m, n = I.shape 
+    m, n = I.shape
     x, y = np.abs(mask).shape
     for i in range(m-x):
         for j in range(n-y):
-            grp.append(I[i:(i+x), j:(j+y)])
-    return grp
+            yield I[i:(i+x), j:(j+y)]
 # }}}
 
 # {{{ difference()
 def difference(I, mask):
     cmask = - mask
     cmask[(mask > 0)] = 0
-    L = []
+    abs_mask = np.abs(mask)
+    counts = {}
     for g in groups(I, mask):
-        flip = (g + cmask) ^ np.abs(mask) - cmask
-        L.append(np.sign(smoothness(flip) - smoothness(g)))
-    N = len(L)
-    R = float(L.count(1))/N
-    S = float(L.count(-1))/N
+        flip = (g + cmask) ^ abs_mask - cmask
+        result = np.sign(smoothness(flip) - smoothness(g))
+        if result not in counts:
+            counts[result] = 0
+        counts[result] += 1
+    N = sum(counts.values())
+    R = float(counts[1])/N
+    S = float(counts[-1])/N
     return R-S
 # }}}
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 numpy
 scipy
-tensorflow==1.15.0
+tensorflow
 keras
 scikit-learn
 scikit-image


### PR DESCRIPTION
RS was looking a little slow - running on the sample_images/lena_lsbr.png took about 330s on my machine. This has it down to ~40s.

Note that I've unpinned the tensorflow 1.15 requirement I'd added in my last PR as that's not available once you're using python 3.8. 