### PR TITLE
Add Octave/Apt/Python dependencies into INSTALL.MD and setup.py

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -6,18 +6,18 @@ You can install Aletheia with the following command:
 $ pip3 install git+https://github.com/daniellerch/aletheia
 ```
 
-But some things might not work properly, because Aletheia has external denpendencies.
+But some things might not work properly, because Aletheia has external dependencies.
 
-Aletheia uses Octave so you need to install it and some of its libraries. You will find the dependencies in the octave-requirements.txt file. In Debian based Linux distributions you can install the dependencies with the following commands. For different distros you can deduce the appropriate ones.
+Aletheia uses Octave, so you need to install it and some of its libraries. You will find the dependencies in the octave-requirements.txt file. In Debian based Linux distributions you can install the dependencies with the following commands. For different distros you can deduce the appropriate ones.
 
 ```bash
-$ sudo apt-get install octave octave-image octave-signal
+$ sudo apt-get install octave octave-image octave-signal octave-nan
 ```
 
 You can find other dependencies in the other-requirements.txt.
 
 ```bash
-$ sudo apt-get install liboctave-dev imagemagick
+$ sudo apt-get install liboctave-dev imagemagick steghide outguess
 ```
 
 After that, you can execute Aletheia with:

--- a/setup.py
+++ b/setup.py
@@ -12,8 +12,8 @@ setup(
     version = '0.2',
     scripts = ['aletheia.py'],
     install_requires = ['imageio', 'numpy', 'scipy', 'tensorflow', 'scikit-learn',
-                        'pandas', 'hdf5storage', 'h5py', ' matplotlib', 
-                        'python-magic'],
+                        'pandas', 'hdf5storage', 'h5py', 'matplotlib',
+                        'steganogan', 'python-magic', 'efficientnet', 'Pillow'],
     include_package_data = True
 )
 


### PR DESCRIPTION
(From https://github.com/openjournals/joss-reviews/issues/5982)

The installation instructions as listed in INSTALL.MD are incomplete and omit a few of the packages listed in `octave-requirements.txt` and `other-requirements.txt`. This adds them into the instruction's apt-get commands since you otherwise run into a few dependency errors.

I also noticed that Pillow is required for a few of the scripts, but was omitted in `setup.py`, so I've gone ahead and synced that with your `requirements.txt` as well. Feel free to change that if any of the omissions were intentional.
